### PR TITLE
fix: converts string to bigint in specific cases when parsing v2 traces

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -90,10 +90,18 @@ function objectToMapRecursive(obj: any): any {
   }
 
   return new Map(
-    Object.entries(obj).map(([key, value]) => [
-      key,
-      objectToMapRecursive(value),
-    ]),
+    Object.entries(obj).map(([key, value]) => {
+      let processedValue = value;
+
+      // Convert string to bigint if key is "uint" and value is a numeric string
+      if (key === 'uint' && typeof value === 'string' && /^\d+$/.test(value)) {
+        processedValue = BigInt(value);
+      } else {
+        processedValue = objectToMapRecursive(value);
+      }
+
+      return [key, processedValue];
+    }),
   );
 }
 


### PR DESCRIPTION
Fixes https://github.com/algorandfoundation/algokit-avm-vscode-debugger/issues/98

The objectToMapRecursive function now converts string values to bigint
when the key is 'uint' and the value is a numeric string.

This is required for some numeric string values that exceed the safe
integer range when users are working with legacy simulation traces emitted from v2 of algosdk
